### PR TITLE
Call and Return now do values on stack.

### DIFF
--- a/VM.Tests/HardwareTests/ProcessorTests.cs
+++ b/VM.Tests/HardwareTests/ProcessorTests.cs
@@ -88,7 +88,7 @@ namespace VM.HardwareTests.Tests
                 processor.Step();
             }
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(expectedAddress.Value));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(expectedAddress.Value));
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace VM.HardwareTests.Tests
 
         private void AssertProcessorIsInInitialState()
         {
-            Assert.That(processor.GetRegister(Register.PC), Is.Zero);
+            Assert.That(processor.ProgramCounter, Is.Zero);
             Assert.That(processor.GetRegister(Register.ACC), Is.Zero);
             Assert.That(processor.GetRegister(Register.FLAG), Is.Zero);
 
@@ -249,11 +249,22 @@ namespace VM.HardwareTests.Tests
         {
             var publicRegisters = new Register[]
             {
+                Register.ACC, Register.FLAG, Register.SP, Register.FP,
+                
                 Register.R0, Register.R1, Register.R2, Register.R3,
                 Register.R4, Register.R5, Register.R6, Register.R7,
+                Register.R8, Register.R9, Register.R10, Register.R11,
+                Register.R12, Register.R13, Register.R14, Register.R15,
+
+                Register.S0, Register.S1, Register.S2, Register.S3,
+                Register.S4, Register.S5, Register.S6, Register.S7,
+                Register.S8, Register.S9, Register.S10, Register.S11,
+                Register.S12, Register.S13, Register.S14, Register.S15,
 
                 Register.T0, Register.T1, Register.T2, Register.T3,
-                Register.T4, Register.T5, Register.T6, Register.T7
+                Register.T4, Register.T5, Register.T6, Register.T7,
+                Register.T8, Register.T9, Register.T10, Register.T11,
+                Register.T12, Register.T13, Register.T14, Register.T15,
             };
 
             foreach (var register in publicRegisters)
@@ -283,7 +294,7 @@ namespace VM.HardwareTests.Tests
         {
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.Not.Zero);
+            Assert.That(processor.ProgramCounter, Is.Not.Zero);
 
             Assert.That(() => processor.GetRegister((Register)0xff), Throws.InvalidOperationException
                 .With.Message.EqualTo("Unknown register 0xFF."));
@@ -1226,7 +1237,7 @@ namespace VM.HardwareTests.Tests
 
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x1234));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(0x1234));
 
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
@@ -1257,7 +1268,7 @@ namespace VM.HardwareTests.Tests
             processor.Step();
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(0x4000));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
 
@@ -1277,7 +1288,7 @@ namespace VM.HardwareTests.Tests
             processor.Step();
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x1234));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(0x1234));
 
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
@@ -1310,7 +1321,7 @@ namespace VM.HardwareTests.Tests
             processor.Step();
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(0x4000));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
 
@@ -1361,14 +1372,14 @@ namespace VM.HardwareTests.Tests
             // Call
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(0x4000));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
 
             // Return
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(returnAddress));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(returnAddress));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS));
 
@@ -1400,7 +1411,7 @@ namespace VM.HardwareTests.Tests
             // Call
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(0x4000));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
 
@@ -1411,7 +1422,7 @@ namespace VM.HardwareTests.Tests
             // Return
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(returnAddress));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(returnAddress));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS));
 
@@ -1458,7 +1469,7 @@ namespace VM.HardwareTests.Tests
             processor.Step();
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(0x4000));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
 
@@ -1473,7 +1484,7 @@ namespace VM.HardwareTests.Tests
             processor.Step();
             processor.Step();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(returnAddress));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(returnAddress));
             Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS));
 
@@ -1611,7 +1622,7 @@ namespace VM.HardwareTests.Tests
 
             processor.Run();
 
-            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(flasher.Address));
+            Assert.That(processor.ProgramCounter, Is.EqualTo(flasher.Address));
 
             Assert.That(haltOccured, Is.True);
         }

--- a/VM.Tests/HardwareTests/ProcessorTests.cs
+++ b/VM.Tests/HardwareTests/ProcessorTests.cs
@@ -12,7 +12,6 @@ namespace VM.HardwareTests.Tests
         private const ushort STACK_SIZE = 0x400;
         private const ushort STACK_START_ADDRESS = (ushort)(MEMORY_SIZE - Processor.DATASIZE);
         private const ushort STACK_END_ADDRESS = STACK_START_ADDRESS - ((STACK_SIZE - 1) * Processor.DATASIZE);
-        private const ushort STATE_SIZE = 18;
 
         private Memory memory;
         private Processor processor;
@@ -230,7 +229,7 @@ namespace VM.HardwareTests.Tests
         {
             var stackRegisters = new Register[]
             {
-                Register.PC, Register.ACC, Register.FLAG, Register.SP, Register.FP
+                Register.PC, Register.ARG, Register.RET
             };
 
             foreach (var register in stackRegisters)
@@ -1221,37 +1220,112 @@ namespace VM.HardwareTests.Tests
 
         #region Subroutines
         [Test]
-        public void CALL_SavesStateAndSetsPCToValue()
+        public void CALL_PushesArgCountAndSetsPCToValue()
         {
-            flasher.WriteInstruction(Instruction.CALL, 0x1234);
+            flasher.WriteInstruction(Instruction.CALL, (ushort)0, 0x1234);
 
             processor.Step();
 
             Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x1234));
 
-            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - STATE_SIZE));
-            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - STATE_SIZE));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+
+            var argPointer = processor.GetRegister(Register.ARG);
+            Assert.That(argPointer, Is.EqualTo(STACK_START_ADDRESS));
+            Assert.That(memory.GetU16(argPointer), Is.EqualTo(0));
         }
 
         [Test]
-        public void CALLR_SavesStateAndSetsPCToValueFromRegister()
+        public void CALL_WithArguments_PushesArgCountAndSetsPCToValueFromRegister()
+        {
+            ushort subroutineAddress = 0x4000;
+
+            LoadValueIntoRegister(0x1111, Register.R0);
+            LoadValueIntoRegister(0x2222, Register.R1);
+
+            flasher.WriteInstruction(Instruction.PUSH, Register.R1);
+            flasher.WriteInstruction(Instruction.PUSH, Register.R0);
+            flasher.WriteInstruction(Instruction.CALL, (ushort)2, subroutineAddress);
+
+            // Load values into registers
+            processor.Step();
+            processor.Step();
+
+            // Push arguments and Call
+            processor.Step();
+            processor.Step();
+            processor.Step();
+
+            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
+
+            var argPointer = processor.GetRegister(Register.ARG);
+            Assert.That(argPointer, Is.EqualTo(STACK_START_ADDRESS - 2 * Processor.DATASIZE));
+            Assert.That(memory.GetU16(argPointer), Is.EqualTo(2));
+            Assert.That(memory.GetU16((ushort)(argPointer + Processor.DATASIZE)), Is.EqualTo(0x1111));
+            Assert.That(memory.GetU16((ushort)(argPointer + 2 * Processor.DATASIZE)), Is.EqualTo(0x2222));
+        }
+
+        [Test]
+        public void CALLR_PushesArgCountAndSetsPCToValueFromRegister()
         {
             LoadValueIntoRegisterR0(0x1234);
-            flasher.WriteInstruction(Instruction.CALLR, Register.R0);
+            flasher.WriteInstruction(Instruction.CALLR, (ushort)0, Register.R0);
 
             processor.Step();
             processor.Step();
 
             Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x1234));
 
-            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - STATE_SIZE));
-            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - STATE_SIZE));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+
+            var argPointer = processor.GetRegister(Register.ARG);
+            Assert.That(argPointer, Is.EqualTo(STACK_START_ADDRESS));
+            Assert.That(memory.GetU16(argPointer), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CALLR_WithArguments_PushesArgCountAndSetsPCToValueFromRegister()
+        {
+            ushort subroutineAddress = 0x4000;
+
+            LoadValueIntoRegister(0x1111, Register.R0);
+            LoadValueIntoRegister(0x2222, Register.R1);
+            LoadValueIntoRegister(subroutineAddress, Register.R2);
+
+            flasher.WriteInstruction(Instruction.PUSH, Register.R1);
+            flasher.WriteInstruction(Instruction.PUSH, Register.R0);
+            flasher.WriteInstruction(Instruction.CALL, (ushort)2, subroutineAddress);
+
+            // Load values into registers
+            processor.Step();
+            processor.Step();
+            processor.Step();
+
+            // Push arguments and Call
+            processor.Step();
+            processor.Step();
+            processor.Step();
+
+            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
+
+            var argPointer = processor.GetRegister(Register.ARG);
+            Assert.That(argPointer, Is.EqualTo(STACK_START_ADDRESS - 2 * Processor.DATASIZE));
+            Assert.That(memory.GetU16(argPointer), Is.EqualTo(2));
+            Assert.That(memory.GetU16((ushort)(argPointer + Processor.DATASIZE)), Is.EqualTo(0x1111));
+            Assert.That(memory.GetU16((ushort)(argPointer + 2 * Processor.DATASIZE)), Is.EqualTo(0x2222));
         }
 
         [Test]
         public void CALL_StackOverflow_ResetsAndThrowsException()
         {
-            FillStack();
+            LoadValueIntoRegister(STACK_END_ADDRESS, Register.SP);
+            processor.Step();
 
             flasher.WriteInstruction(Instruction.CALL, 0x1234);
 
@@ -1261,38 +1335,65 @@ namespace VM.HardwareTests.Tests
         [Test]
         public void CALLR_StackOverflow_ResetsAndThrowsException()
         {
-            FillStack();
-
+            LoadValueIntoRegister(STACK_END_ADDRESS, Register.SP);
             LoadValueIntoRegisterR0(0x1234);
-            flasher.WriteInstruction(Instruction.CALLR, Register.R0);
 
             processor.Step();
+            processor.Step();
+
+            flasher.WriteInstruction(Instruction.CALLR, Register.R0);
+
             AssertExceptionOccursAndProcessorResets(typeof(StackOverflowException), "Stack is full.");
         }
 
         [Test]
-        public void RET_LoadsSavedStateAndSetsPCToValueBeforeCall()
+        public void RET_WithOutReturnValues_PushesReturnCountAndResetsPC()
         {
             ushort subroutineAddress = 0x4000;
 
-            LoadValueIntoRegister(0x0123, Register.R0);
-            LoadValueIntoRegister(0x4567, Register.R1);
-            LoadValueIntoRegister(0x89ab, Register.R2);
-            LoadValueIntoRegister(0xcdef, Register.R3);
-            flasher.WriteInstruction(Instruction.CALL, subroutineAddress);
+            flasher.WriteInstruction(Instruction.CALL, (ushort)0, subroutineAddress);
 
             var returnAddress = flasher.Address;
 
             flasher.Address = subroutineAddress;
-            LoadValueIntoRegister(0xffff, Register.R0);
-            LoadValueIntoRegister(0xffff, Register.R1);
-            LoadValueIntoRegister(0xffff, Register.R2);
-            LoadValueIntoRegister(0xffff, Register.R3);
-            flasher.WriteInstruction(Instruction.RET);
+            flasher.WriteInstruction(Instruction.RET, (ushort)0);
+
+            // Call
+            processor.Step();
+
+            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+
+            // Return
+            processor.Step();
+
+            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(returnAddress));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS));
+
+            var retPointer = processor.GetRegister(Register.RET);
+            Assert.That(retPointer, Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+            Assert.That(memory.GetU16(retPointer), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void RET_WithReturnValues_PushesReturnCountAndResetsPC()
+        {
+            ushort subroutineAddress = 0x4000;
+
+            LoadValueIntoRegister(0x1111, Register.R0);
+            LoadValueIntoRegister(0x2222, Register.R1);
+            flasher.WriteInstruction(Instruction.CALL, (ushort)0, subroutineAddress);
+
+            var returnAddress = flasher.Address;
+
+            flasher.Address = subroutineAddress;
+            flasher.WriteInstruction(Instruction.PUSH, Register.R1);
+            flasher.WriteInstruction(Instruction.PUSH, Register.R0);
+            flasher.WriteInstruction(Instruction.RET, 2);
 
             // Load values into registers
-            processor.Step();
-            processor.Step();
             processor.Step();
             processor.Step();
 
@@ -1300,31 +1401,25 @@ namespace VM.HardwareTests.Tests
             processor.Step();
 
             Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
-            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 18));
-            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 18));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
 
-            // Overwrite registers
+            // Push Return values
             processor.Step();
             processor.Step();
-            processor.Step();
-            processor.Step();
-
-            Assert.That(processor.GetRegister(Register.R0), Is.EqualTo(0xffff));
-            Assert.That(processor.GetRegister(Register.R1), Is.EqualTo(0xffff));
-            Assert.That(processor.GetRegister(Register.R2), Is.EqualTo(0xffff));
-            Assert.That(processor.GetRegister(Register.R3), Is.EqualTo(0xffff));
 
             // Return
             processor.Step();
 
             Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(returnAddress));
-            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - Processor.DATASIZE));
             Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS));
 
-            Assert.That(processor.GetRegister(Register.R0), Is.EqualTo(0x0123));
-            Assert.That(processor.GetRegister(Register.R1), Is.EqualTo(0x4567));
-            Assert.That(processor.GetRegister(Register.R2), Is.EqualTo(0x89ab));
-            Assert.That(processor.GetRegister(Register.R3), Is.EqualTo(0xcdef));
+            var retPointer = processor.GetRegister(Register.RET);
+            Assert.That(retPointer, Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
+            Assert.That(memory.GetU16(retPointer), Is.EqualTo(2));
+            Assert.That(memory.GetU16((ushort)(retPointer + Processor.DATASIZE)), Is.EqualTo(0x1111));
+            Assert.That(memory.GetU16((ushort)(retPointer + 2 * Processor.DATASIZE)), Is.EqualTo(0x2222));
         }
 
         [Test]
@@ -1332,45 +1427,61 @@ namespace VM.HardwareTests.Tests
         {
             flasher.WriteInstruction(Instruction.RET);
 
-            AssertExceptionOccursAndProcessorResets(typeof(InvalidOperationException), "Stack is empty.");
+            AssertExceptionOccursAndProcessorResets(typeof(InvalidOperationException), "In base frame, nothing to return to.");
         }
 
         [Test]
         public void Subroutine_AcceptsArgumentsAndReturnsValues()
         {
-            var instructionCount = 0;
-            ushort subroutineAddress = 0x1000;
+            ushort subroutineAddress = 0x4000;
 
-            LoadValueIntoRegister(1, Register.R0);
-            LoadValueIntoRegister(2, Register.R1);
-            LoadValueIntoRegister(3, Register.R2);
-            LoadValueIntoRegister(4, Register.R3);
-            flasher.WriteInstruction(Instruction.MOVE, Register.R0, Register.A0);
-            flasher.WriteInstruction(Instruction.MOVE, Register.R1, Register.A1);
-            flasher.WriteInstruction(Instruction.MOVE, Register.R2, Register.A2);
-            flasher.WriteInstruction(Instruction.MOVE, Register.R3, Register.A3);
+            LoadValueIntoRegister(0x1111, Register.R0);
+            LoadValueIntoRegister(0x2222, Register.R1);
 
-            flasher.WriteInstruction(Instruction.CALL, subroutineAddress);
+            flasher.WriteInstruction(Instruction.PUSH, Register.R1);
+            flasher.WriteInstruction(Instruction.PUSH, Register.R0);
+            flasher.WriteInstruction(Instruction.CALL, (ushort)2, subroutineAddress);
 
-            flasher.WriteInstruction(Instruction.ADD, Register.V0, Register.V1);
+            var returnAddress = flasher.Address;
 
-            instructionCount += flasher.InstructionCount;
             flasher.Address = subroutineAddress;
+            flasher.WriteInstruction(Instruction.PUSH, Register.R1);
+            flasher.WriteInstruction(Instruction.PUSH, Register.R0);
+            flasher.WriteInstruction(Instruction.RET, 2);
 
-            flasher.WriteInstruction(Instruction.ADD, Register.A0, Register.A1);
-            flasher.WriteInstruction(Instruction.MOVE, Register.ACC, Register.V0);
-            flasher.WriteInstruction(Instruction.ADD, Register.A2, Register.A3);
-            flasher.WriteInstruction(Instruction.MOVE, Register.ACC, Register.V1);
-            flasher.WriteInstruction(Instruction.RET);
+            // Load values into registers
+            processor.Step();
+            processor.Step();
 
-            instructionCount += flasher.InstructionCount;
+            // Push arguments and Call
+            processor.Step();
+            processor.Step();
+            processor.Step();
 
-            for (var i = 0; i < instructionCount; i++)
-            {
-                processor.Step();
-            }
+            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(0x4000));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS - 5 * Processor.DATASIZE));
 
-            Assert.That(processor.GetRegister(Register.ACC), Is.EqualTo(10));
+            var argPointer = processor.GetRegister(Register.ARG);
+            Assert.That(argPointer, Is.EqualTo(STACK_START_ADDRESS - 2 * Processor.DATASIZE));
+            Assert.That(memory.GetU16(argPointer), Is.EqualTo(2));
+            Assert.That(memory.GetU16((ushort)(argPointer + Processor.DATASIZE)), Is.EqualTo(0x1111));
+            Assert.That(memory.GetU16((ushort)(argPointer + 2 * Processor.DATASIZE)), Is.EqualTo(0x2222));
+
+            // Push return values and Return
+            processor.Step();
+            processor.Step();
+            processor.Step();
+
+            Assert.That(processor.GetRegister(Register.PC), Is.EqualTo(returnAddress));
+            Assert.That(processor.GetRegister(Register.SP), Is.EqualTo(STACK_START_ADDRESS - 3 * Processor.DATASIZE));
+            Assert.That(processor.GetRegister(Register.FP), Is.EqualTo(STACK_START_ADDRESS));
+
+            var retPointer = processor.GetRegister(Register.RET);
+            Assert.That(retPointer, Is.EqualTo(STACK_START_ADDRESS - 7 * Processor.DATASIZE));
+            Assert.That(memory.GetU16(retPointer), Is.EqualTo(2));
+            Assert.That(memory.GetU16((ushort)(retPointer + Processor.DATASIZE)), Is.EqualTo(0x1111));
+            Assert.That(memory.GetU16((ushort)(retPointer + 2 * Processor.DATASIZE)), Is.EqualTo(0x2222));
         }
 
         [Test]
@@ -1383,7 +1494,7 @@ namespace VM.HardwareTests.Tests
                 0x1000, 0x2000, 0x3000, 0x4000, 0x5000
             };
 
-            flasher.WriteInstruction(Instruction.CALL, addresses[0]);
+            flasher.WriteInstruction(Instruction.CALL, (ushort)0, addresses[0]);
             instructionCount += flasher.InstructionCount;
 
             for (ushort i = 0; i < addresses.Length; i++)
@@ -1396,10 +1507,10 @@ namespace VM.HardwareTests.Tests
 
                 if (i != addresses.Length - 1)
                 {
-                    flasher.WriteInstruction(Instruction.CALL, addresses[i + 1]);
+                    flasher.WriteInstruction(Instruction.CALL, (ushort)0, addresses[i + 1]);
                 }
 
-                flasher.WriteInstruction(Instruction.RET);
+                flasher.WriteInstruction(Instruction.RET, (ushort)0);
                 instructionCount += flasher.InstructionCount;
             }
 

--- a/VM.Tests/HardwareTests/StackTests.cs
+++ b/VM.Tests/HardwareTests/StackTests.cs
@@ -14,17 +14,8 @@ namespace VM.HardwareTests.Tests
         [SetUp]
         public void SetUp()
         {
-            memory = new Memory(0x100);
-            stack = new Stack(memory, 0xfe, 0xf0);
-        }
-
-        private void FillStack()
-        {
-            for (var i = 0; i < 8; i++)
-            {
-                stack.Push((ushort)i);
-                stack.PushFrame();
-            }
+            memory = new Memory(0x20);
+            stack = new Stack(memory, 0x1e, 0x0a);
         }
 
         [Test]
@@ -73,18 +64,18 @@ namespace VM.HardwareTests.Tests
         [Test]
         public void Push_AddsValueToStack()
         {
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
 
             stack.Push(0x1234);
 
-            Assert.That(memory.GetU16(0xfe), Is.EqualTo(0x1234));
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfc));
+            Assert.That(memory.GetU16(0x1e), Is.EqualTo(0x1234));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1c));
         }
 
         [Test]
         public void Push_StackOverflow_ThrowsException()
         {
-            for (ushort i = 0; i < 8; i++)
+            for (ushort i = 0; i < 11; i++)
             {
                 stack.Push(i);
             }
@@ -96,13 +87,13 @@ namespace VM.HardwareTests.Tests
         [Test]
         public void Pop_RemovesValueFromStack()
         {
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
 
             stack.Push(0x1234);
             var value = stack.Pop();
 
             Assert.That(value, Is.EqualTo(0x1234));
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
         }
 
         [Test]
@@ -115,13 +106,13 @@ namespace VM.HardwareTests.Tests
         [Test]
         public void Peek_ReturnsValueWithoutRemovingFromStack()
         {
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
 
             stack.Push(0x1234);
             var value = stack.Peek();
 
             Assert.That(value, Is.EqualTo(0x1234));
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfc));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1c));
         }
 
         [Test]
@@ -134,7 +125,7 @@ namespace VM.HardwareTests.Tests
         [Test]
         public void MultiplePeeks_ReturnSameValue()
         {
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
 
             stack.Push(0x1234);
 
@@ -145,13 +136,13 @@ namespace VM.HardwareTests.Tests
                 Assert.That(value, Is.EqualTo(0x1234));
             }
 
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfc));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1c));
         }
 
         [Test]
         public void ValuesArePoppedInReversePushOrder()
         {
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
 
             var pushValues = new ushort[] { 0, 1, 2, 3 };
 
@@ -168,83 +159,181 @@ namespace VM.HardwareTests.Tests
             }
 
             Assert.That(values, Is.EqualTo(new ushort[] { 3, 2, 1, 0 }));
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
         }
 
         [Test]
-        public void PushFrame_StartsANewFrame()
+        public void Call_StartsANewFrame()
         {
-            stack.Push(1);
+            stack.Push(0x1111);
 
-            stack.PushFrame();
+            stack.Call(0xffff, 0x1234);
+
+            Assert.That(stack.FramePointer, Is.EqualTo(0x16));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x16));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x1c));
+            Assert.That(memory.GetU16(stack.ArgumentsPointer), Is.EqualTo(0xffff));
 
             Assert.That(() => stack.Pop(), Throws.InvalidOperationException
                 .With.Message.EqualTo("Stack frame is empty."));
         }
 
         [Test]
-        public void PushFrame_MultipleFrames()
+        public void Call_MultipleFrames()
         {
-            FillStack();
+            stack.Call(0x1111, 0x0123);
 
-            for (var i = 0; i < 8; i++)
-            {
-                stack.PopFrame();
-            }
+            Assert.That(stack.FramePointer, Is.EqualTo(0x18));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x18));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x1e));
+            Assert.That(memory.GetU16(stack.ArgumentsPointer), Is.EqualTo(0x1111));
 
-            Assert.That(stack.Pop(), Is.EqualTo(0));
+            stack.Call(0x2222, 0x4567);
 
-            Assert.That(() => stack.Pop(), Throws.InvalidOperationException
-                .With.Message.EqualTo("Stack frame is empty."));
+            Assert.That(stack.FramePointer, Is.EqualTo(0x12));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x12));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x18));
+            Assert.That(memory.GetU16(stack.ArgumentsPointer), Is.EqualTo(0x2222));
+
+            stack.Call(0x3333, 0x89ab);
+
+            Assert.That(stack.FramePointer, Is.EqualTo(0x0c));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x0c));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x12));
+            Assert.That(memory.GetU16(stack.ArgumentsPointer), Is.EqualTo(0x3333));
         }
 
         [Test]
-        public void PushFrame_StackOverflow()
+        public void Call_StackOverflow()
         {
-            FillStack();
+            stack.Call(0x1111, 0x0123);
+            stack.Call(0x2222, 0x4567);
+            stack.Call(0x3333, 0x89ab);
 
-            Assert.That(() => stack.Push(1), Throws.InstanceOf<StackOverflowException>()
+            Assert.That(() => stack.Call(0x4444, 0xcdef), Throws.InstanceOf<StackOverflowException>()
                 .With.Message.EqualTo("Stack is full."));
         }
 
         [Test]
-        public void PopFrame_GoesBackToPreviousFrame()
+        public void Return_GoesBackToPreviousFrame()
         {
-            stack.Push(1);
+            stack.Call(0x1111, 0x0123); // 1
+            stack.Call(0x2222, 0x4567); // 2
+            stack.Call(0x3333, 0x89ab); // 3
 
-            stack.PushFrame();
+            // subroutine 3
+            Assert.That(stack.FramePointer, Is.EqualTo(0x0c));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x0c));
 
-            stack.PopFrame();
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x12));
+            Assert.That(memory.GetU16(stack.ArgumentsPointer), Is.EqualTo(0x3333));
 
-            Assert.That(stack.Pop(), Is.EqualTo(1));
+            stack.Push(0xfedc);
+            Assert.That(stack.Return(1), Is.EqualTo(0x89ab));
+
+            // subroutine 2
+            Assert.That(stack.FramePointer, Is.EqualTo(0x12));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x10));
+
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x0a));
+            Assert.That(memory.GetU16(stack.ReturnsPointer), Is.EqualTo(1));
+            Assert.That(memory.GetU16((ushort)(stack.ReturnsPointer + Processor.DATASIZE)), Is.EqualTo(0xfedc));
+
+            stack.Push(0xba98);
+            Assert.That(stack.Return(1), Is.EqualTo(0x4567));
+
+            // subroutine 1
+            Assert.That(stack.FramePointer, Is.EqualTo(0x18));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x16));
+
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x0e));
+            Assert.That(memory.GetU16(stack.ReturnsPointer), Is.EqualTo(1));
+            Assert.That(memory.GetU16((ushort)(stack.ReturnsPointer + Processor.DATASIZE)), Is.EqualTo(0xba98));
+
+            stack.Push(0x7654);
+            Assert.That(stack.Return(1), Is.EqualTo(0x0123));
+
+            // main
+            Assert.That(stack.FramePointer, Is.EqualTo(0x1e));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1c));
+
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x14));
+            Assert.That(memory.GetU16(stack.ReturnsPointer), Is.EqualTo(1));
+            Assert.That(memory.GetU16((ushort)(stack.ReturnsPointer + Processor.DATASIZE)), Is.EqualTo(0x7654));
         }
 
         [Test]
-        public void PopFrame_EmptyStack_ThrowsException()
+        public void Return_EmptyStack_ThrowsException()
         {
-            Assert.That(() => stack.PopFrame(), Throws.InvalidOperationException
-                .With.Message.EqualTo("Stack is empty."));
+            Assert.That(() => stack.Return(0), Throws.InvalidOperationException
+                .With.Message.EqualTo("In base frame, nothing to return to."));
+        }
+
+        [Test]
+        public void CallAndReturn_MultipleValues()
+        {
+            Assert.That(stack.FramePointer, Is.EqualTo(0x1e));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x1e));
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x1e));
+
+            stack.Push(0x2222);
+            stack.Push(0x1111);
+
+            stack.Call(2, 0x1234);
+
+            Assert.That(stack.FramePointer, Is.EqualTo(0x14));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x14));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x1a));
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x1e));
+
+            Assert.That(memory.GetU16(stack.ArgumentsPointer), Is.EqualTo(2));
+            Assert.That(memory.GetU16((ushort)(stack.ArgumentsPointer + Processor.DATASIZE)), Is.EqualTo(0x1111));
+            Assert.That(memory.GetU16((ushort)(stack.ArgumentsPointer + 2 * Processor.DATASIZE)), Is.EqualTo(0x2222));
+
+            stack.Push(0x4444);
+            stack.Push(0x3333);
+
+            stack.Return(2);
+
+            Assert.That(stack.FramePointer, Is.EqualTo(0x1e));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x18));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x1a));
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x10));
+
+            Assert.That(memory.GetU16(stack.ReturnsPointer), Is.EqualTo(2));
+            Assert.That(memory.GetU16((ushort)(stack.ReturnsPointer + Processor.DATASIZE)), Is.EqualTo(0x3333));
+            Assert.That(memory.GetU16((ushort)(stack.ReturnsPointer + 2 * Processor.DATASIZE)), Is.EqualTo(0x4444));
         }
 
         [Test]
         public void Reset_ResetsStack()
         {
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.FramePointer, Is.EqualTo(0x1e));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x1e));
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x1e));
 
-            stack.PushFrame();
+            stack.Call(0x1111, 0x0123); // 1
+            stack.Call(0x2222, 0x4567); // 2
 
-            var pushValues = new ushort[] { 0, 1, 2, 3 };
+            stack.Push(0xba98);
+            Assert.That(stack.Return(1), Is.EqualTo(0x4567));
 
-            foreach (var value in pushValues)
-            {
-                stack.Push(value);
-            }
+            // subroutine 1
+            Assert.That(stack.FramePointer, Is.EqualTo(0x18));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x16));
 
-            Assert.That(stack.StackPointer, Is.EqualTo(0xf6));
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x10));
+            Assert.That(memory.GetU16(stack.ReturnsPointer), Is.EqualTo(1));
+            Assert.That(memory.GetU16((ushort)(stack.ReturnsPointer + Processor.DATASIZE)), Is.EqualTo(0xba98));
 
             stack.Reset();
 
-            Assert.That(stack.StackPointer, Is.EqualTo(0xfe));
+            Assert.That(stack.FramePointer, Is.EqualTo(0x1e));
+            Assert.That(stack.StackPointer, Is.EqualTo(0x1e));
+            Assert.That(stack.ArgumentsPointer, Is.EqualTo(0x1e));
+            Assert.That(stack.ReturnsPointer, Is.EqualTo(0x1e));
         }
     }
 }

--- a/VM/Hardware/ArithmeticLogicUnit.cs
+++ b/VM/Hardware/ArithmeticLogicUnit.cs
@@ -8,12 +8,12 @@
         /// <summary>
         /// Result of all <see cref="Instruction"/>s are stored here.
         /// </summary>
-        public ushort Accumulator { get; private set; }
+        public ushort Accumulator { get; set; }
 
         /// <summary>
         /// <see cref="Flags"/> indicating results of <see cref="Instruction"/>s.
         /// </summary>
-        public Flags Flag { get; private set; }
+        public Flags Flag { get; set; }
 
         /// <summary>
         /// Next Address to following a Conditional Jump <see cref="Instruction"/>.

--- a/VM/Hardware/Extensions.cs
+++ b/VM/Hardware/Extensions.cs
@@ -24,6 +24,11 @@ namespace VM.Hardware
             return Enum.GetName(typeof(Register), register);
         }
 
+        public static ushort MemoryAddress(this Register register)
+        {
+            return (ushort)((register - Register.R0) * Processor.DATASIZE);
+        } 
+
         public static bool IsValid(this Instruction instruction)
         {
             return IsValid<Instruction>(instruction);

--- a/VM/Hardware/Extensions.cs
+++ b/VM/Hardware/Extensions.cs
@@ -6,22 +6,17 @@ namespace VM.Hardware
     {
         public static bool IsPrivate(this Register register)
         {
-            return register < Register.R0;
+            return register < Register.ACC;
         }
 
-        public static bool IsStack(this Register register)
+        private static bool IsValid<T>(T value)
         {
-            return register == Register.SP || register == Register.FP;
-        }
-
-        public static bool IsAlu(this Register register)
-        {
-            return register == Register.ACC || register == Register.FLAG;
+            return Enum.IsDefined(value.GetType(), value);
         }
 
         public static bool IsValid(this Register register)
         {
-            return Enum.IsDefined(typeof(Register), register);
+            return IsValid<Register>(register);
         }
 
         public static string Name(this Register register)
@@ -31,7 +26,7 @@ namespace VM.Hardware
 
         public static bool IsValid(this Instruction instruction)
         {
-            return Enum.IsDefined(typeof(Instruction), instruction);
+            return IsValid<Instruction>(instruction);
         }
 
         public static bool IsCarryFlag(this Instruction instruction)

--- a/VM/Instruction.cs
+++ b/VM/Instruction.cs
@@ -298,17 +298,17 @@
         #region Subroutine Instructions
         /// <summary>
         /// Call subroutine at address.<br/>
-        /// Arguments: Address (<see cref="ushort"/>).
+        /// Arguments: Arguments Count (<see cref="ushort"/>), Address (<see cref="ushort"/>).
         /// </summary>
         CALL,
         /// <summary>
         /// Call subroutine at address in Register.<br/>
-        /// Arguments: Address (<see cref="Register"/>).
+        /// Arguments: Arguments Count (<see cref="ushort"/>), Address (<see cref="Register"/>).
         /// </summary>
         CALLR,
         /// <summary>
         /// Return from subroutine.<br/>
-        /// Arguments: NONE
+        /// Arguments: Return Values Count (<see cref="ushort"/>).
         /// </summary>
         RET,
         #endregion

--- a/VM/Register.cs
+++ b/VM/Register.cs
@@ -12,6 +12,16 @@
         /// </summary>
         PC,
         /// <summary>
+        /// Pointer to Subroutine argument count.
+        /// Arguments will be below this value (higher address) on the <see cref="Hardware.Stack"/>.
+        /// </summary>
+        ARG,
+        /// <summary>
+        /// Pointer to Subroutine return values count.
+        /// Return values will be below this value (higher address) on the <see cref="Hardware.Stack"/>.
+        /// </summary>
+        RET,
+        /// <summary>
         /// Accumulator.
         /// Where result of all Arithmetic and Bitwise <see cref="Instruction"/>s is stored.
         /// </summary>
@@ -63,76 +73,166 @@
         /// General purpose register.
         /// </summary>
         R7,
-        #endregion
-
-        #region Temporary Registers
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
+        /// </summary>
+        R8,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        R9,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        R10,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        R11,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        R12,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        R13,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        R14,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        R15,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S0,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S1,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S2,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S3,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S4,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S5,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S6,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S7,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S8,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S9,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S10,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S11,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S12,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S13,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S14,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        S15,
+        /// <summary>
+        /// General purpose register.
         /// </summary>
         T0,
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
         /// </summary>
         T1,
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
         /// </summary>
         T2,
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
         /// </summary>
         T3,
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
         /// </summary>
         T4,
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
         /// </summary>
         T5,
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
         /// </summary>
         T6,
         /// <summary>
         /// General purpose register.
-        /// Not preserved during subroutines.
         /// </summary>
         T7,
-        #endregion
-
-        #region Subroutine Registers
         /// <summary>
-        /// Subroutine Argument Register
+        /// General purpose register.
         /// </summary>
-        A0,
+        T8,
         /// <summary>
-        /// Subroutine Argument Register
+        /// General purpose register.
         /// </summary>
-        A1,
+        T9,
         /// <summary>
-        /// Subroutine Argument Register
+        /// General purpose register.
         /// </summary>
-        A2,
+        T10,
         /// <summary>
-        /// Subroutine Argument Register
+        /// General purpose register.
         /// </summary>
-        A3,
+        T11,
         /// <summary>
-        /// Subroutine Return Value Register
+        /// General purpose register.
         /// </summary>
-        V0,
+        T12,
         /// <summary>
-        /// Subroutine Return Value Register
+        /// General purpose register.
         /// </summary>
-        V1
+        T13,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        T14,
+        /// <summary>
+        /// General purpose register.
+        /// </summary>
+        T15,
         #endregion
     }
 }

--- a/VM/Utility.cs
+++ b/VM/Utility.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
 using System.Globalization;
+using VM.Hardware;
 
-namespace VM.Hardware
+namespace VM
 {
     class Utility
     {
@@ -23,6 +26,11 @@ namespace VM.Hardware
         public static IEnumerable<byte> GetBytes(ushort value)
         {
             return new byte[] { (byte)((value >> 8) & 0xff), (byte)(value & 0xff) };
+        }
+
+        public static ushort GeneralPurposeRegisterMemorySize()
+        {
+            return (ushort)((Enum.GetValues(typeof(Register)).Length - (int)Register.R0) * Processor.DATASIZE);
         }
     }
 }

--- a/VM/VM.csproj
+++ b/VM/VM.csproj
@@ -70,7 +70,7 @@
     <Compile Include="Register.cs" />
     <Compile Include="Hardware\ResetEventArgs.cs" />
     <Compile Include="Hardware\Stack.cs" />
-    <Compile Include="Hardware\Utility.cs" />
+    <Compile Include="Utility.cs" />
     <Compile Include="Hardware\MemoryWriteEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- replaces A# and V# registers with pushing to stack
- CALL, CALLR, and RET now take a count argument
- added more registers (ARG, RET, R0-16, S0-16, T0-16)
- registers not preserved through subroutine (on caller to save on stack)
- Most registers now editable in code